### PR TITLE
[Dev Tools] Switch to Ava from tap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ dist
 .tern-port
 .vscode/
 package-lock.json
+
+# Wallaby.js configuration
+wallaby.conf.js

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "lint": "standard && npm run lint:typescript",
     "lint:fix": "standard --fix",
     "lint:typescript": "standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin types/**/*.ts",
-    "test": "tap test/**/*.test.js && tsd",
-    "test:unit": "tap test/**/*.test.js",
+    "test": "c8 --100 ava & tsd",
+    "test:unit": "ava",
     "test:types": "tsd"
   },
   "repository": {
@@ -37,11 +37,12 @@
     "@types/node": "^20.1.0",
     "@typescript-eslint/eslint-plugin": "^5.46.0",
     "@typescript-eslint/parser": "^5.46.0",
+    "ava": "^5.3.1",
+    "c8": "^8.0.0",
     "fastify": "^4.4.0",
     "mercurius": "^13.0.0",
     "split2": "^4.1.0",
     "standard": "^17.0.0",
-    "tap": "^16.3.0",
     "tsd": "^0.28.0"
   },
   "dependencies": {

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const test = require('ava')
 const Fastify = require('fastify')
 const mercurius = require('mercurius')
 const split = require('split2')
@@ -66,8 +66,8 @@ test('should log every query', async (t) => {
 
   const stream = split(JSON.parse)
   stream.on('data', line => {
-    t.same(line.reqId, 'req-1')
-    t.same(line.graphql, {
+    t.is(line.reqId, 'req-1')
+    t.deepEqual(line.graphql, {
       queries: ['add', 'add', 'echo', 'counter']
     })
   })
@@ -87,7 +87,7 @@ test('should log every query', async (t) => {
     url: '/graphql',
     body: JSON.stringify({ query })
   })
-  t.same(response.json(), {
+  t.deepEqual(response.json(), {
     data: {
       four: 4,
       six: 6,
@@ -102,8 +102,8 @@ test('should log prepend the alias', async (t) => {
 
   const stream = split(JSON.parse)
   stream.on('data', line => {
-    t.same(line.reqId, 'req-1')
-    t.same(line.graphql, {
+    t.is(line.reqId, 'req-1')
+    t.deepEqual(line.graphql, {
       queries: ['four:add', 'six:add', 'echo', 'counter']
     })
   })
@@ -123,7 +123,7 @@ test('should log prepend the alias', async (t) => {
     url: '/graphql',
     body: JSON.stringify({ query })
   })
-  t.same(response.json(), {
+  t.deepEqual(response.json(), {
     data: {
       four: 4,
       six: 6,
@@ -138,8 +138,8 @@ test('should log every mutation', async (t) => {
 
   const stream = split(JSON.parse)
   stream.on('data', line => {
-    t.same(line.reqId, 'req-1')
-    t.same(line.graphql, {
+    t.is(line.reqId, 'req-1')
+    t.deepEqual(line.graphql, {
       mutations: ['plusOne', 'minusOne', 'plusOne']
     })
   })
@@ -158,7 +158,7 @@ test('should log every mutation', async (t) => {
     body: JSON.stringify({ query })
   })
 
-  t.same(response.json(), {
+  t.deepEqual(response.json(), {
     data: {
       plusOne: 1,
       minusOne: 0,
@@ -172,9 +172,9 @@ test('should log at debug level', async (t) => {
 
   const stream = split(JSON.parse)
   stream.on('data', line => {
-    t.same(line.level, 20)
-    t.same(line.reqId, 'req-1')
-    t.same(line.graphql, {
+    t.is(line.level, 20)
+    t.is(line.reqId, 'req-1')
+    t.deepEqual(line.graphql, {
       mutations: ['plusOne']
     })
   })
@@ -188,7 +188,7 @@ test('should log at debug level', async (t) => {
     body: JSON.stringify({ query })
   })
 
-  t.same(response.json(), {
+  t.deepEqual(response.json(), {
     data: {
       plusOne: 2
     }
@@ -206,8 +206,8 @@ test('should log the request body', async (t) => {
 
   const stream = split(JSON.parse)
   stream.on('data', line => {
-    t.same(line.reqId, 'req-1')
-    t.same(line.graphql, {
+    t.is(line.reqId, 'req-1')
+    t.deepEqual(line.graphql, {
       queries: ['add', 'add', 'echo'],
       body: query
     })
@@ -221,7 +221,7 @@ test('should log the request body', async (t) => {
     url: '/graphql',
     body: JSON.stringify({ query })
   })
-  t.same(response.json(), {
+  t.deepEqual(response.json(), {
     data: { four: 4, six: 6, echo: 'hellohello' }
   })
 })
@@ -237,18 +237,18 @@ test('should log the request body based on the function', async (t) => {
   stream.on('data', line => {
     switch (line.reqId) {
       case 'req-1':
-        t.same(line.graphql, {
+        t.deepEqual(line.graphql, {
           queries: ['echo']
         })
         break
       case 'req-2':
-        t.same(line.graphql, {
+        t.deepEqual(line.graphql, {
           queries: ['echo'],
           body: query
         })
         break
       case 'req-3':
-        t.same(line.graphql, {
+        t.deepEqual(line.graphql, {
           queries: ['echo']
         })
         break
@@ -276,7 +276,7 @@ test('should log the request body based on the function', async (t) => {
       url: '/graphql',
       body: JSON.stringify({ query, variables: { txt: 'false' } })
     })
-    t.same(response.json(), {
+    t.deepEqual(response.json(), {
       data: { echo: 'falsefalse' }
     })
   }
@@ -288,7 +288,7 @@ test('should log the request body based on the function', async (t) => {
       url: '/graphql',
       body: JSON.stringify({ query, variables: { txt: 'true' } })
     })
-    t.same(response.json(), {
+    t.deepEqual(response.json(), {
       data: { echo: 'truetrue' }
     })
   }
@@ -300,7 +300,7 @@ test('should log the request body based on the function', async (t) => {
       url: '/graphql',
       body: JSON.stringify({ query, variables: { txt: 'err' } })
     })
-    t.same(response.json(), {
+    t.deepEqual(response.json(), {
       data: { echo: 'errerr' }
     })
   }
@@ -317,8 +317,8 @@ test('should log the request variables', async (t) => {
 
   const stream = split(JSON.parse)
   stream.on('data', line => {
-    t.same(line.reqId, 'req-1')
-    t.same(line.graphql, {
+    t.is(line.reqId, 'req-1')
+    t.deepEqual(line.graphql, {
       queries: ['add', 'add', 'echo'],
       variables: { num: 2 }
     })
@@ -333,7 +333,7 @@ test('should log the request variables', async (t) => {
     body: JSON.stringify({ query, variables: { num: 2 } })
   })
 
-  t.same(response.json(), {
+  t.deepEqual(response.json(), {
     data: { a: 4, b: 4, echo: 'hellohello' }
   })
 })
@@ -348,8 +348,8 @@ test('should log the request variables as null when missing', async (t) => {
 
   const stream = split(JSON.parse)
   stream.on('data', line => {
-    t.same(line.reqId, 'req-1')
-    t.same(line.graphql, {
+    t.is(line.reqId, 'req-1')
+    t.deepEqual(line.graphql, {
       queries: ['add', 'echo'],
       variables: null
     })
@@ -364,7 +364,7 @@ test('should log the request variables as null when missing', async (t) => {
     body: JSON.stringify({ query })
   })
 
-  t.same(response.json(), {
+  t.deepEqual(response.json(), {
     data: { add: 4, echo: 'hellohello' }
   })
 })
@@ -385,8 +385,8 @@ test('should log the whole request when operationName is set', async (t) => {
 
   const stream = split(JSON.parse)
   stream.on('data', line => {
-    t.same(line.reqId, 'req-1')
-    t.same(line.graphql, {
+    t.is(line.reqId, 'req-1')
+    t.deepEqual(line.graphql, {
       queries: ['add', 'add', 'add', 'add'],
       operationName: 'baam',
       body: query,
@@ -410,5 +410,5 @@ test('should log the whole request when operationName is set', async (t) => {
     })
   })
 
-  t.same(response.json(), { data: { c: 5, d: 5 } })
+  t.deepEqual(response.json(), { data: { c: 5, d: 5 } })
 })

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,4 +1,3 @@
-
 import fastify from 'fastify'
 import { MercuriusContext } from 'mercurius'
 


### PR DESCRIPTION
I've switched the test runner to [ava](https://github.com/avajs/ava), which has similar ergonomics to `tap`,
but runs everything in parallel.  It also supports integration with [Wallaby](https://wallabyjs.com/) for a
great test writing environment in the editor.

Test Plan:

- [x] Unit tests pass!