### PR TITLE
fix: handle undefined reply object inside mercurius context

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Here a complete example when you turn on all the log options:
 }
 ```
 
+If the [mercurius `graphql` decorator](https://github.com/mercurius-js/mercurius/blob/master/docs/api/options.md#appgraphqlsource-context-variables-operationname) is used, it is necessary to provide a `context` object: `app.graphql(query, { reply })`.
+Otherwise, this plugin will ignore the request.
+
 ## Install
 
 ```

--- a/index.js
+++ b/index.js
@@ -41,6 +41,11 @@ function mercuriusLogging (app, opts, next) {
 }
 
 function logGraphQLDetails (opts, schema, document, context) {
+  // Reply object could be undefined. In this case, we can't log.
+  if (!context.reply) {
+    return
+  }
+
   const queryOps = readOps(document, 'query', opts)
   const mutationOps = readOps(document, 'mutation', opts)
 

--- a/test/handle-reply-undefined.test.js
+++ b/test/handle-reply-undefined.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('ava')
-const { buildApp } = require('./_helper')
+const { buildApp, jsonLogger } = require('./_helper')
 
 test('should handle without logging when context.reply is undefined', async (t) => {
   t.plan(1)
@@ -16,6 +16,46 @@ test('should handle without logging when context.reply is undefined', async (t) 
     counter
   }`
     return app.graphql(query)
+  })
+
+  const response = await app.inject({
+    method: 'GET',
+    headers: { 'content-type': 'application/json' },
+    url: '/custom-endpoint'
+  })
+
+  t.deepEqual(response.json(), {
+    data: {
+      four: 4,
+      six: 6,
+      echo: 'hellohello',
+      counter: 0
+    }
+  })
+})
+
+test('should log when using graphql mercurius decorator providing reply object inside context', async (t) => {
+  t.plan(4)
+
+  const stream = jsonLogger(
+    line => {
+      t.is(line.req, undefined)
+      t.is(line.reqId, 'req-1')
+      t.deepEqual(line.graphql, {
+        queries: ['add', 'add', 'echo', 'counter']
+      })
+    })
+
+  const app = buildApp(t, { stream })
+
+  app.get('/custom-endpoint', async function (_, reply) {
+    const query = `query {
+    four: add(x: 2, y: 2)
+    six: add(x: 3, y: 3)
+    echo(msg: "hello")
+    counter
+  }`
+    return app.graphql(query, { reply })
   })
 
   const response = await app.inject({

--- a/test/handle-reply-undefined.test.js
+++ b/test/handle-reply-undefined.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const test = require('ava')
+const { buildApp } = require('./_helper')
+
+test('should handle without logging when context.reply is undefined', async (t) => {
+  t.plan(1)
+
+  const app = buildApp(t)
+
+  app.get('/custom-endpoint', async function () {
+    const query = `query {
+    four: add(x: 2, y: 2)
+    six: add(x: 3, y: 3)
+    echo(msg: "hello")
+    counter
+  }`
+    return app.graphql(query)
+  })
+
+  const response = await app.inject({
+    method: 'GET',
+    headers: { 'content-type': 'application/json' },
+    url: '/custom-endpoint'
+  })
+
+  t.deepEqual(response.json(), {
+    data: {
+      four: 4,
+      six: 6,
+      echo: 'hellohello',
+      counter: 0
+    }
+  })
+})


### PR DESCRIPTION
There's a scenario where "reply" object inside mercurius context is undefined. In this case, the plugin crashes whit the following error: 

`{
    "error": "Internal Server Error",
    "message": "Cannot read properties of undefined (reading 'request')",
    "statusCode": 500
}`  

We found this problem in our use case:
- Create a fastify GET endpoint, executing internally the graphql mercurius federation query for sdl `{ _service { sdl } }`.
- Create a test for new endpoint, triggering request via fastify.inject.
 
In this PR i added a guard, checking if context.reply is not undefined. In case of undefined, the plugin doesn't make anything.